### PR TITLE
Make pkill usage optional

### DIFF
--- a/bin/snipe
+++ b/bin/snipe
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 require 'ostruct'
 require 'optparse'
 
@@ -59,6 +59,11 @@ parser = OptionParser.new do |config|
   config.on("-d", "--dry-run", desc) do
     options.no_signals = true
   end
+
+  desc = "Use the pkill utility to send the signal (targetted process only)"
+  config.on("--pkill", desc) do
+    options.pkill = true
+  end
 end.parse!
 
 # TODO remove me
@@ -88,6 +93,7 @@ signaller = Snipr::ProcessSignaller.new do |signaller|
   end
   signaller.signal          options.signal
   signaller.target_parent   options.target_parent
+  signaller.pkill if options.pkill
   signaller.dry_run if options.no_signals
 
   if options.bytes


### PR DESCRIPTION
This adds a CLI flag to toggle shelling out to `pkill` to send the signal (target processes only). This should ensure that behavior remains consistent for users of previous versions of snipr and still works in environments where `pkill` is not available.

It also adds a check to ensure the PID that is signaled hasn't been recycled by ensuring the `cmdline` reported by procfs matches what we captured when locating the processes. This is similar to what `pkill` does behind the scenes, albeit a bit slower.